### PR TITLE
feat(monitoring): stabilise check

### DIFF
--- a/monitoring/scripted_browser.js
+++ b/monitoring/scripted_browser.js
@@ -16,15 +16,21 @@
  */
 const assert = require('assert');
 
-async function check() {
-  await $browser.get('$$$URL$$$');
-  // load-more is the last DOM element injected by the scripts - wait for it
-  await $browser.waitForAndFindElement($driver.By.css('.load-more'), 60000);
-  const articles = await $browser.findElements($driver.By.css('.card'));
-  // Check if there are enough articles
-  assert.ok(articles.length >= 13, `Expected at least 13 articles, got ${articles.length}`);
-  // Check if first item is special
-  const value = await articles[0].getCssValue('flex-direction');
-  assert.equal(value, 'row', `Expected flex-direction of first article to be "row", got "${value}"" instead.`);
-}
-check();
+$browser.get('$$$URL$$$')
+  // Get articles
+  .then(() => {
+    console.log(`Page loaded. Waiting now for '.load-more' element...`);
+    return $browser.waitForAndFindElement($driver.By.css('.load-more'), 60000);
+  }).then(() => {
+    console.log(`'.load-more' found. Retrieving the articles...`);
+    return $browser.findElements($driver.By.css('.card'));
+  }).then((articles) => {
+    // Check if there are enough articles
+    console.log(`Found ${articles.length} articles in the page.`);
+    assert.ok(articles.length >= 13, `Expected at least 13 articles, got ${articles.length}`);
+    // Check if first item is special
+    return articles[0].getCssValue('flex-direction');
+  }).then((value) => {
+    console.log(`flex-direction of first article is ${value}.`);
+    assert.equal(value, 'row', `Expected flex-direction of first article to be "row", got "${value}"" instead.`);
+  });

--- a/monitoring/scripted_browser.js
+++ b/monitoring/scripted_browser.js
@@ -16,14 +16,15 @@
  */
 const assert = require('assert');
 
-$browser.get('$$$URL$$$')
-  // Get articles
-  .then(() => $browser.findElements($driver.By.css('.card'))
-    .then((articles) => {
-      // Check if there are enough articles
-      assert.ok(articles.length >= 13, `Expected at least 13 articles, got ${articles.length}`);
-      // Check if first item is special
-      return articles[0].getCssValue('flex-direction').then((value) => {
-        assert.equal(value, 'row', `Expected flex-direction of first article to be "row", got "${value}"" instead.`);
-      });
-    }));
+async function check() {
+  await $browser.get('$$$URL$$$');
+  // load-more is the last DOM element injected by the scripts - wait for it
+  await $browser.waitForAndFindElement($driver.By.css('.load-more'), 60000);
+  const articles = await $browser.findElements($driver.By.css('.card'));
+  // Check if there are enough articles
+  assert.ok(articles.length >= 13, `Expected at least 13 articles, got ${articles.length}`);
+  // Check if first item is special
+  const value = await articles[0].getCssValue('flex-direction');
+  assert.equal(value, 'row', `Expected flex-direction of first article to be "row", got "${value}"" instead.`);
+}
+check();


### PR DESCRIPTION
I am adding `$browser.waitForAndFindElement($driver.By.css('.load-more'), 60000);` for the check to "wait" until `.load-more` element to be loaded in the DOM. This is the last piece injected by the client script and "guaranties" that the `query-index.json` request has made the round-trip. 
The tests are failing for unknown reasons while everything has been loaded fine. Only noticeable piece: `query-index.json`  took longer than usual (several seconds): waiting for the `.load-more` element should guaranty the json has been fully loaded and processed when the check is executed.

https://one.newrelic.com/launcher/nr1-core.explorer?pane=eyJjaGVja0lkIjoiN2Y1NjlhMDctYmNlMC00MGQwLWFhNDAtYWY4NTg5NWUyY2NkIiwibmVyZGxldElkIjoic3ludGhldGljcy1uZXJkbGV0cy5tb25pdG9yLXJlc3VsdC1kZXRhaWxzIiwiZW50aXR5SWQiOiJNalF5T1RNek5IeFRXVTVVU0h4TlQwNUpWRTlTZkdWaE4ySm1aRGczTFRCalpHTXROR1ZqTmkxaVl6UmhMV1JrTmpZd09UYzRaVFl4TVEifQ==&sidebars[0]=eyJuZXJkbGV0SWQiOiJucjEtY29yZS5hY3Rpb25zIiwiZW50aXR5SWQiOiJNalF5T1RNek5IeFRXVTVVU0h4TlQwNUpWRTlTZkdWaE4ySm1aRGczTFRCalpHTXROR1ZqTmkxaVl6UmhMV1JrTmpZd09UYzRaVFl4TVEiLCJzZWxlY3RlZE5lcmRsZXQiOnsibmVyZGxldElkIjoic3ludGhldGljcy1uZXJkbGV0cy5tb25pdG9yLXJlc3VsdC1kZXRhaWxzIn19&platform[accountId]=2429334&platform[timeRange][duration]=1800000&platform[$isFallbackTimeRange]=true