### PR TITLE
feat(monitoring/homepage_test.js): add blog monit

### DIFF
--- a/monitoring/scripted_browser.js
+++ b/monitoring/scripted_browser.js
@@ -19,10 +19,10 @@ const assert = require('assert');
 $browser.get('$$$URL$$$')
   // Get articles
   .then(() => {
-    console.log(`Page loaded. Waiting now for '.load-more' element...`);
+    console.log('Page loaded. Waiting now for \'.load-more\' element...');
     return $browser.waitForAndFindElement($driver.By.css('.load-more'), 60000);
   }).then(() => {
-    console.log(`'.load-more' found. Retrieving the articles...`);
+    console.log('\'.load-more\' found. Retrieving the articles...');
     return $browser.findElements($driver.By.css('.card'));
   }).then((articles) => {
     // Check if there are enough articles
@@ -30,7 +30,8 @@ $browser.get('$$$URL$$$')
     assert.ok(articles.length >= 13, `Expected at least 13 articles, got ${articles.length}`);
     // Check if first item is special
     return articles[0].getCssValue('flex-direction');
-  }).then((value) => {
+  })
+  .then((value) => {
     console.log(`flex-direction of first article is ${value}.`);
     assert.equal(value, 'row', `Expected flex-direction of first article to be "row", got "${value}"" instead.`);
   });

--- a/test/smoke/test.post.content.output.js
+++ b/test/smoke/test.post.content.output.js
@@ -24,7 +24,6 @@ const urlPrefix = `https://theblog-adobe.${testDomain}`;
 const url = `${urlPrefix}/en/publish/2020/03/19/introducing-public-beta.html`;
 
 describe(`Test theblog post page content for page ${url}`, () => {
-
   it('contains the expected content', async () => {
     const $ = await utils.getContentAs$(url);
     assert.equal('Introducing Public Beta', $('title').text(), 'title');

--- a/test/smoke/test.sitemap.output.js
+++ b/test/smoke/test.sitemap.output.js
@@ -35,7 +35,7 @@ testURLs.forEach((url) => {
     it('contains the expected structure', () => {
       assert.equal($('urlset').length, 1, 'has urlset tag');
       assert.ok($('urlset > url').length > 0, 'has 1+ url tags');
-      assert.equal(new URL($('urlset > url > loc')[0].textContent.trim()).hostname, `blog.adobe.com`, 'uses correct host name');
+      assert.equal(new URL($('urlset > url > loc')[0].textContent.trim()).hostname, 'blog.adobe.com', 'uses correct host name');
     });
   });
 });

--- a/test/smoke/utils.js
+++ b/test/smoke/utils.js
@@ -21,11 +21,11 @@ let res;
 async function getContentAs$(url, contentType = 'text/html') {
   try {
     res = await fetch(url,
-    {
-      headers: {
-      // 'x-debug': '<use fastly service id here>',
-      },
-    });
+      {
+        headers: {
+          // 'x-debug': '<use fastly service id here>',
+        },
+      });
 
     assert.equal(res.status, 200);
     assert.equal(res.ok, true);


### PR DESCRIPTION
enable helix devs to see when the homepage is failing with 404s
as this is the most prominent content that necessarily must be up

feat #23