### PR TITLE
chore: switch default branch from master to main

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,4 +82,4 @@ workflows:
           context: Project Helix
           filters:
             branches:
-              only: master
+              only: main


### PR DESCRIPTION
There's no reason why the default branch should remain `master`.

See https://github.com/adobe/helix-home/issues/140